### PR TITLE
Add support for "Filter workspace users" route

### DIFF
--- a/Clockify.Net/ClockifyClient.Users.cs
+++ b/Clockify.Net/ClockifyClient.Users.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Clockify.Net.Models;
 using Clockify.Net.Models.Users;
-using Clockify.Net.Models.Workspaces;
 using RestSharp;
 
 namespace Clockify.Net

--- a/Clockify.Net/ClockifyClient.Users.cs
+++ b/Clockify.Net/ClockifyClient.Users.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Clockify.Net.Models;
 using Clockify.Net.Models.Users;
+using Clockify.Net.Models.Workspaces;
 using RestSharp;
 
 namespace Clockify.Net
@@ -12,12 +13,13 @@ namespace Clockify.Net
         /// <summary>
         /// Find all users on workspace
         /// </summary>
-        public async Task<Response<List<UserDto>>> FindAllUsersOnWorkspaceAsync(string workspaceId, int page = 1, int pageSize = 50)
+        public async Task<Response<List<UserDto>>> FindAllUsersOnWorkspaceAsync(string workspaceId, int page = 1, int pageSize = 50, bool includeRoles = false)
         {
             var request = new RestRequest($"workspaces/{workspaceId}/users");
 
             request.AddQueryParameter(nameof(page), page.ToString());
             request.AddQueryParameter("page-size", pageSize.ToString());
+            request.AddQueryParameter("includeRoles", includeRoles);
 
             return Response<List<UserDto>>.FromRestResponse(await _client.ExecuteGetAsync<List<UserDto>>(request).ConfigureAwait(false));
         }
@@ -45,6 +47,14 @@ namespace Clockify.Net
         {
             var request = new RestRequest($"users/{userId}/activeWorkspace/{workspaceId}");
             return Response<UserDto>.FromRestResponse(await _experimentalClient.ExecutePostAsync<UserDto>(request).ConfigureAwait(false));
+        }
+
+        public async Task<Response<List<UserDto>>> FilterWorkspaceUsers(string workspaceId, WorkspaceUsersRequest requestBody)
+        {
+            var request = new RestRequest($"/workspaces/{workspaceId}/users/info");
+            request.AddJsonBody(requestBody);
+
+            return Response<List<UserDto>>.FromRestResponse(await _client.ExecuteAsync<List<UserDto>>(request, Method.Post).ConfigureAwait(false));
         }
     }
 }

--- a/Clockify.Net/Models/Users/RoleType.cs
+++ b/Clockify.Net/Models/Users/RoleType.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Clockify.Net.Models.Users
+{
+    public enum RoleType
+    {
+        [EnumMember(Value = "WORKSPACE_ADMIN")]
+        WORKSPACE_ADMIN,
+        [EnumMember(Value = "OWNER")]
+        OWNER,
+        [EnumMember(Value = "TEAM_MANAGER")]
+        TEAM_MANAGER,
+        [EnumMember(Value = "PROJECT_MANAGER")]
+        PROJECT_MANAGER
+    }
+}

--- a/Clockify.Net/Models/Users/SortColumnType.cs
+++ b/Clockify.Net/Models/Users/SortColumnType.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Clockify.Net.Models.Users
+{
+    public enum SortColumnType
+    {
+        [EnumMember(Value = "ID")]
+        ID,
+        [EnumMember(Value = "EMAIL")]
+        EMAIL,
+        [EnumMember(Value = "NAME")]
+        NAME,
+        [EnumMember(Value = "NAME_LOWERCASE")]
+        NAME_LOWERCASE,
+        [EnumMember(Value = "ACCESS")]
+        ACCESS,
+        [EnumMember(Value = "HOURLYRATE")]
+        HOURLYRATE,
+        [EnumMember(Value = "COSTRATE")]
+        COSTRATE
+    }
+}

--- a/Clockify.Net/Models/Users/StatusType.cs
+++ b/Clockify.Net/Models/Users/StatusType.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Clockify.Net.Models.Users
+{
+    public enum StatusType
+    {
+        [EnumMember(Value = "PENDING")]
+        PENDING,
+        [EnumMember(Value = "ACTIVE")]
+        ACTIVE,
+        [EnumMember(Value = "DECLINED")]
+        DECLINED,
+        [EnumMember(Value = "INACTIVE")]
+        INACTIVE,
+        [EnumMember(Value = "ALL")]
+        ALL
+    }
+}

--- a/Clockify.Net/Models/Users/UserDto.cs
+++ b/Clockify.Net/Models/Users/UserDto.cs
@@ -14,5 +14,6 @@ namespace Clockify.Net.Models.Users
         public string ProfilePicture { get; set; }
         public UserSettingsDto Settings { get; set; }
         public UserStatus? Status { get; set; }
+        public List<UserRolesDto> Roles { get; set; }
     }
 }

--- a/Clockify.Net/Models/Users/UserDto.cs
+++ b/Clockify.Net/Models/Users/UserDto.cs
@@ -9,11 +9,11 @@ namespace Clockify.Net.Models.Users
         public string DefaultWorkspace { get; set; }
         public string Email { get; set; }
         public string ID { get; set; }
-        public List<MembershipDto> Memberships { get; set; }
+        public List<MembershipDto> Memberships { get; set; } = [];
         public string Name { get; set; }
         public string ProfilePicture { get; set; }
         public UserSettingsDto Settings { get; set; }
         public UserStatus? Status { get; set; }
-        public List<UserRolesDto> Roles { get; set; }
+        public List<UserRolesDto> Roles { get; set; } = [];
     }
 }

--- a/Clockify.Net/Models/Users/UserRolesDto.cs
+++ b/Clockify.Net/Models/Users/UserRolesDto.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Clockify.Net.Models.Users
+{
+    public class UserRolesDto
+    {
+        public string FormatterRoleName { get; set; }
+        public string Role { get; set; }
+
+        public List<Entities> Entities { get; set; }
+
+    }
+
+    public class Entities
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/Clockify.Net/Models/Users/UserRolesDto.cs
+++ b/Clockify.Net/Models/Users/UserRolesDto.cs
@@ -9,7 +9,7 @@ namespace Clockify.Net.Models.Users
         public string FormatterRoleName { get; set; }
         public string Role { get; set; }
 
-        public List<Entities> Entities { get; set; }
+        public List<Entities> Entities { get; set; } = [];
 
     }
 

--- a/Clockify.Net/Models/Users/WorkspaceUsersRequest.cs
+++ b/Clockify.Net/Models/Users/WorkspaceUsersRequest.cs
@@ -1,0 +1,37 @@
+﻿using Clockify.Net.Models.Reports;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Clockify.Net.Models.Users
+{
+    public class WorkspaceUsersRequest
+    {
+        // SETTINGS (OPTIONAL)
+        public string Email { get; set; }
+
+        public bool IncludeRoles { get; set; }
+
+        public string Memberships { get; set; }
+
+        public string Name { get; set; }
+
+        public int Page { get; set; }
+
+        public int PageSize { get; set; }
+
+        public string ProjectId { get; set; }
+
+        public List<RoleType> Roles { get; set; }
+
+        public SortColumnType SortColumn { get; set; }
+
+        public SortOrderType SortOrder { get; set; }
+
+        public StatusType Status { get; set; }
+
+        public List<string> UserGroups { get; set; }
+
+    }
+}

--- a/Clockify.Net/Models/Users/WorkspaceUsersRequest.cs
+++ b/Clockify.Net/Models/Users/WorkspaceUsersRequest.cs
@@ -23,7 +23,7 @@ namespace Clockify.Net.Models.Users
 
         public string ProjectId { get; set; }
 
-        public List<RoleType> Roles { get; set; }
+        public List<RoleType> Roles { get; set; } = [];
 
         public SortColumnType SortColumn { get; set; }
 
@@ -31,7 +31,6 @@ namespace Clockify.Net.Models.Users
 
         public StatusType Status { get; set; }
 
-        public List<string> UserGroups { get; set; }
-
+        public List<string> UserGroups { get; set; } = [];
     }
 }


### PR DESCRIPTION
Add method ```FilterWorkspaceUsers``` to ```ClockifyClient.Users```.
This covers https://docs.clockify.me/#tag/User/operation/filterUsersOfWorkspace.

Add Roles member to ```UserDTO``` to fully support the new route.
Add ```includeRoles``` parameter to ```FindAllUsersOnWorkspaceAsync``` while at it.

Tests are included and ran through.
Tests are a little buggy right now due to the refactor of ClockifyClient.
You need to add the API Key manually to each ClockifyClient or reimplement ```GetApiKeyFromEnv()```.
